### PR TITLE
DM-35486: Add image impact of errors

### DIFF
--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -192,7 +192,7 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
         plt.subplot(3, 3, 4)
         plt.plot(fit_times, az_error, color='red')
 
-        plt.title(f"Azimuth RMS error = {az_rms:.2f} arcseconds\n" + \
+        plt.title(f"Azimuth RMS error = {az_rms:.2f} arcseconds\n"
                   f"  Image RMS error = {image_az_rms:.2f} arcseconds")
         plt.ylim(-10.0, 10.0)
         plt.xticks([])
@@ -211,7 +211,7 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
         ax2.set_xticks([])
         plt.subplot(3, 3, 5)
         plt.plot(fit_times, el_error, color='green')
-        plt.title(f"Elevation RMS error = {el_rms:.2f} arcseconds\n" + \
+        plt.title(f"Elevation RMS error = {el_rms:.2f} arcseconds\n"
                   f"    Image RMS error = {image_el_rms:.2f} arcseconds")
         plt.ylim(-10.0, 10.0)
         plt.xticks([])
@@ -228,8 +228,8 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
         ax3.set_xticks([])
         plt.subplot(3, 3, 6)
         plt.plot(fit_times, rot_error, color='blue')
-        plt.title(f"Nasmyth RMS error = {rot_rms:.2f} arcseconds\n" + \
-                  f"  Image RMS error <= {image_rot_rms:.2f} arcseconds")
+        plt.title(f"Nasmyth RMS error = {rot_rms:.2f} arcseconds\n"
+                  f" Image RMS error <= {image_rot_rms:.2f} arcseconds")
         plt.ylim(-10.0, 10.0)
         plt.subplot(3, 3, 9)
         ax9 = rot_torque['nasmyth2MotorTorque'].plot(legend=True, color='blue')

--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -229,8 +229,8 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
         ax3.set_xticks([])
         plt.subplot(3, 3, 6)
         plt.plot(fit_times, rot_error, color='blue')
-        plt.title(f"Nasmyth RMS error = {rot_rms:.2f} arcseconds\n"
-                  f" Image RMS error <= {image_rot_rms:.2f} arcseconds")
+        plt.title(f"Nasmyth2 RMS error = {rot_rms:.2f} arcseconds\n"
+                  f"  Image RMS error <= {image_rot_rms:.2f} arcseconds")
         plt.ylim(-10.0, 10.0)
         plt.subplot(3, 3, 9)
         ax9 = rot_torque['nasmyth2MotorTorque'].plot(legend=True, color='blue')

--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -48,8 +48,9 @@ def _getEfdData(client, dataSeries, startTime, endTime):
     return loop.run_until_complete(client.select_time_series(dataSeries, ['*'], startTime.utc, endTime.utc))
 
 
-def plotMountTracking(dataId, butler, client, figure, saveFilename, logger):
-    """Queries EFD for given exposure and checks if there were tracking errors.
+def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
+    """Queries EFD for a given exposure and calculates the RMS errors in the
+    axes during the exposure, optionally plotting and saving the data.
 
     Parameters
     ----------
@@ -69,8 +70,11 @@ def plotMountTracking(dataId, butler, client, figure, saveFilename, logger):
 
     Returns
     -------
-    plotted : `bool`
-        True if the dataId was plotted, False if it was skipped.
+    axisErrors : `tuple` of (`np.array`)
+        The RMS errors in the three axes:
+            `az_rms` : The RMS in azimuth
+            `el_rms` : The RMS in elevation
+            `rot_rms` : The RMS in the rotator
     """
     # lsst-efd-client is not a required import at the top here, but is
     # implicitly required as a client is passed into this function so is not

--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -38,6 +38,7 @@ NON_TRACKING_IMAGE_TYPES = ['BIAS',
                             'DARK',
                             ]
 
+AUXTEL_ANGLE_TO_EDGE_OF_FIELD_ARCSEC = 280.0
 
 def _getEfdData(client, dataSeries, startTime, endTime):
     """A synchronous warpper for geting the data from the EFD.
@@ -70,7 +71,7 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
 
     Returns
     -------
-    axisErrors : `list` of (`np.array`)
+    axisErrors : `list` [`numpy.ndarray`], (3, N)
         The RMS errors in the three axes:
             `az_rms` : The RMS in azimuth
             `el_rms` : The RMS in elevation
@@ -171,7 +172,7 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
     # Calculate Image impact RMS
     image_az_rms = az_rms * np.cos(el_vals[0] * np.pi / 180.0)
     image_el_rms = el_rms
-    image_rot_rms = rot_rms * 280.0 * np.pi / 180.0 / 3600.0
+    image_rot_rms = rot_rms * AUXTEL_ANGLE_TO_EDGE_OF_FIELD_ARCSEC * np.pi / 180.0 / 3600.0
 
     end = time.time()
     elapsed = end-start

--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -70,7 +70,7 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
 
     Returns
     -------
-    axisErrors : `tuple` of (`np.array`)
+    axisErrors : `list` of (`np.array`)
         The RMS errors in the three axes:
             `az_rms` : The RMS in azimuth
             `el_rms` : The RMS in elevation

--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -164,68 +164,77 @@ def plotMountTracking(dataId, butler, client, figure, saveFilename, logger):
     el_rms = np.sqrt(np.mean(el_error * el_error))
     rot_rms = np.sqrt(np.mean(rot_error * rot_error))
 
+    # Calculate Image impact RMS
+    image_az_rms = az_rms * np.cos(el_vals[0] * np.pi / 180.0)
+    image_el_rms = el_rms
+    image_rot_rms = rot_rms * 280.0 * np.pi / 180.0 / 3600.0
+
     end = time.time()
     elapsed = end-start
     logger.debug(f"Elapsed time for error calculations = {elapsed}")
     start = time.time()
+    if saveFilename is not None:
+        # Plotting
+        figure.clear()
+        title = f"Mount Tracking {dataIdString}, Azimuth = {azimuth:.1f}, Elevation = {elevation:.1f}"
+        plt.suptitle(title, fontsize=18)
+        # Azimuth axis
+        plt.subplot(3, 3, 1)
+        ax1 = az['azimuthCalculatedAngle'].plot(legend=True, color='red')
+        ax1.set_title("Azimuth axis", fontsize=16)
+        ax1.axvline(az.index[0], color="red", linestyle="--")
+        ax1.set_xticks([])
+        ax1.set_ylabel("Degrees")
+        plt.subplot(3, 3, 4)
+        plt.plot(fit_times, az_error, color='red')
 
-    # Plotting
-    figure.clear()
-    title = f"Mount Tracking {dataIdString}, Azimuth = {azimuth:.1f}, Elevation = {elevation:.1f}"
-    plt.suptitle(title, fontsize=18)
-    # Azimuth axis
-    plt.subplot(3, 3, 1)
-    ax1 = az['azimuthCalculatedAngle'].plot(legend=True, color='red')
-    ax1.set_title("Azimuth axis", fontsize=16)
-    ax1.axvline(az.index[0], color="red", linestyle="--")
-    ax1.set_xticks([])
-    ax1.set_ylabel("Degrees")
-    plt.subplot(3, 3, 4)
-    plt.plot(fit_times, az_error, color='red')
-    plt.title(f"Azimuth RMS error = {az_rms:.2f} arcseconds")
-    plt.ylim(-10.0, 10.0)
-    plt.xticks([])
-    plt.ylabel("Arcseconds")
-    plt.subplot(3, 3, 7)
-    ax7 = az_torque_1['azimuthMotor1Torque'].plot(legend=True, color='blue')
-    ax7 = az_torque_2['azimuthMotor2Torque'].plot(legend=True, color='green')
-    ax7.axvline(az.index[0], color="red", linestyle="--")
-    ax7.set_ylabel("Torque (motor current in amps)")
+        plt.title(f"Azimuth RMS error = {az_rms:.2f} arcseconds\n" + \
+                  f"  Image RMS error = {image_az_rms:.2f} arcseconds")
+        plt.ylim(-10.0, 10.0)
+        plt.xticks([])
+        plt.ylabel("Arcseconds")
+        plt.subplot(3, 3, 7)
+        ax7 = az_torque_1['azimuthMotor1Torque'].plot(legend=True, color='blue')
+        ax7 = az_torque_2['azimuthMotor2Torque'].plot(legend=True, color='green')
+        ax7.axvline(az.index[0], color="red", linestyle="--")
+        ax7.set_ylabel("Torque (motor current in amps)")
 
-    # Elevation axis
-    plt.subplot(3, 3, 2)
-    ax2 = el['elevationCalculatedAngle'].plot(legend=True, color='green')
-    ax2.set_title("Elevation axis", fontsize=16)
-    ax2.axvline(az.index[0], color="red", linestyle="--")
-    ax2.set_xticks([])
-    plt.subplot(3, 3, 5)
-    plt.plot(fit_times, el_error, color='green')
-    plt.title(f"Elevation RMS error = {el_rms:.2f} arcseconds")
-    plt.ylim(-10.0, 10.0)
-    plt.xticks([])
-    plt.subplot(3, 3, 8)
-    ax8 = el_torque['elevationMotorTorque'].plot(legend=True, color='blue')
-    ax8.axvline(az.index[0], color="red", linestyle="--")
-    ax8.set_ylabel("Torque (motor current in amps)")
+        # Elevation axis
+        plt.subplot(3, 3, 2)
+        ax2 = el['elevationCalculatedAngle'].plot(legend=True, color='green')
+        ax2.set_title("Elevation axis", fontsize=16)
+        ax2.axvline(az.index[0], color="red", linestyle="--")
+        ax2.set_xticks([])
+        plt.subplot(3, 3, 5)
+        plt.plot(fit_times, el_error, color='green')
+        plt.title(f"Elevation RMS error = {el_rms:.2f} arcseconds\n" + \
+                  f"    Image RMS error = {image_el_rms:.2f} arcseconds")
+        plt.ylim(-10.0, 10.0)
+        plt.xticks([])
+        plt.subplot(3, 3, 8)
+        ax8 = el_torque['elevationMotorTorque'].plot(legend=True, color='blue')
+        ax8.axvline(az.index[0], color="red", linestyle="--")
+        ax8.set_ylabel("Torque (motor current in amps)")
 
-    # Nasmyth2 rotator axis
-    plt.subplot(3, 3, 3)
-    ax3 = rot['nasmyth2CalculatedAngle'].plot(legend=True, color='blue')
-    ax3.set_title("Nasmyth2 axis", fontsize=16)
-    ax3.axvline(az.index[0], color="red", linestyle="--")
-    ax3.set_xticks([])
-    plt.subplot(3, 3, 6)
-    plt.plot(fit_times, rot_error, color='blue')
-    plt.title(f"Nasmyth RMS error = {rot_rms:.2f} arcseconds")
-    plt.ylim(-100.0, 100.0)
-    plt.subplot(3, 3, 9)
-    ax9 = rot_torque['nasmyth2MotorTorque'].plot(legend=True, color='blue')
-    ax9.axvline(az.index[0], color="red", linestyle="--")
-    ax9.set_ylabel("Torque (motor current in amps)")
-    plt.savefig(saveFilename)
+        # Nasmyth2 rotator axis
+        plt.subplot(3, 3, 3)
+        ax3 = rot['nasmyth2CalculatedAngle'].plot(legend=True, color='blue')
+        ax3.set_title("Nasmyth2 axis", fontsize=16)
+        ax3.axvline(az.index[0], color="red", linestyle="--")
+        ax3.set_xticks([])
+        plt.subplot(3, 3, 6)
+        plt.plot(fit_times, rot_error, color='blue')
+        plt.title(f"Nasmyth RMS error = {rot_rms:.2f} arcseconds\n" + \
+                  f"  Image RMS error <= {image_rot_rms:.2f} arcseconds")
+        plt.ylim(-10.0, 10.0)
+        plt.subplot(3, 3, 9)
+        ax9 = rot_torque['nasmyth2MotorTorque'].plot(legend=True, color='blue')
+        ax9.axvline(az.index[0], color="red", linestyle="--")
+        ax9.set_ylabel("Torque (motor current in amps)")
+        plt.savefig(saveFilename)
 
-    end = time.time()
-    elapsed = end-start
-    logger.debug(f"Elapsed time for plots = {elapsed}")
+        end = time.time()
+        elapsed = end-start
+        logger.debug(f"Elapsed time for plots = {elapsed}")
 
-    return True
+    return [az_rms, el_rms, rot_rms]

--- a/python/lsst/rubintv/production/mountTorques.py
+++ b/python/lsst/rubintv/production/mountTorques.py
@@ -40,6 +40,7 @@ NON_TRACKING_IMAGE_TYPES = ['BIAS',
 
 AUXTEL_ANGLE_TO_EDGE_OF_FIELD_ARCSEC = 280.0
 
+
 def _getEfdData(client, dataSeries, startTime, endTime):
     """A synchronous warpper for geting the data from the EFD.
 
@@ -232,6 +233,7 @@ def calculateMountErrors(dataId, butler, client, figure, saveFilename, logger):
         plt.title(f"Nasmyth2 RMS error = {rot_rms:.2f} arcseconds\n"
                   f"  Image RMS error <= {image_rot_rms:.2f} arcseconds")
         plt.ylim(-10.0, 10.0)
+        plt.xticks([])
         plt.subplot(3, 3, 9)
         ax9 = rot_torque['nasmyth2MotorTorque'].plot(legend=True, color='blue')
         ax9.axvline(az.index[0], color="red", linestyle="--")

--- a/python/lsst/rubintv/production/rubinTv.py
+++ b/python/lsst/rubintv/production/rubinTv.py
@@ -455,9 +455,12 @@ class MountTorqueChannel():
         try:
             tempFilename = tempfile.mktemp(suffix='.png')
             uploadFilename = _dataIdToFilename(self.channel, dataId)
-            plotted = calculateMountErrors(dataId, self.butler, self.client, self.fig, tempFilename, self.log)
 
-            if plotted:  # skips many image types and short exps
+            # calculateMountErrors() calculates the errors, but also performs
+            # the plotting. We don't need the errors here so we throw them away
+            _ = calculateMountErrors(dataId, self.butler, self.client, self.fig, tempFilename, self.log)
+
+            if os.path.exists(tempFilename):  # skips many image types and short exps
                 self.log.info("Uploading mount torque plot to storage bucket")
                 self.uploader.googleUpload(self.channel, tempFilename, uploadFilename)
                 self.log.info('Upload complete')

--- a/python/lsst/rubintv/production/rubinTv.py
+++ b/python/lsst/rubintv/production/rubinTv.py
@@ -53,7 +53,7 @@ from lsst.summit.utils.butlerUtils import (makeDefaultLatissButler, datasetExist
 from lsst.summit.utils.utils import dayObsIntToString
 from lsst.atmospec.utils import isDispersedDataId
 
-from lsst.rubintv.production.mountTorques import plotMountTracking
+from lsst.rubintv.production.mountTorques import calculateMountErrors
 from lsst.rubintv.production.monitorPlotting import plotExp
 
 CHANNELS = ["summit_imexam",
@@ -455,7 +455,7 @@ class MountTorqueChannel():
         try:
             tempFilename = tempfile.mktemp(suffix='.png')
             uploadFilename = _dataIdToFilename(self.channel, dataId)
-            plotted = plotMountTracking(dataId, self.butler, self.client, self.fig, tempFilename, self.log)
+            plotted = calculateMountErrors(dataId, self.butler, self.client, self.fig, tempFilename, self.log)
 
             if plotted:  # skips many image types and short exps
                 self.log.info("Uploading mount torque plot to storage bucket")


### PR DESCRIPTION
This change adds the image impact of the tracking errors.  The AZ error is scaled by cos(EL) and the rotator error is calculated as r*theta, where r is the angular distance to the corner of the field (280 arcseconds for AuxTel) and theta is the rotator tracking error.  Attached is a graph with the change:
[Mount_Torques_2022052600012.pdf](https://github.com/lsst-sitcom/rubintv_production/files/9065275/Mount_Torques_2022052600012.pdf)
