### PR TITLE
DM-37244: Render images with bad headers

### DIFF
--- a/python/lsst/rubintv/production/starTracker.py
+++ b/python/lsst/rubintv/production/starTracker.py
@@ -282,14 +282,17 @@ class StarTrackerChannel():
         # DATE-OBS is present in the original header, but it's being
         # stripped out and somehow not set (plus it doesn't give the midpoint
         # of the exposure), so set it manually from the midpoint here
-        md = exp.getMetadata()
-        begin = datetime.datetime.fromisoformat(md['DATE-BEG'])
-        end = datetime.datetime.fromisoformat(md['DATE-END'])
-        duration = end - begin
-        mid = begin + duration/2
-        newTime = dafBase.DateTime(mid.isoformat(), dafBase.DateTime.Timescale.TAI)
-        newVi = exp.visitInfo.copyWith(date=newTime)
-        exp.info.setVisitInfo(newVi)
+        try:
+            md = exp.getMetadata()
+            begin = datetime.datetime.fromisoformat(md['DATE-BEG'])
+            end = datetime.datetime.fromisoformat(md['DATE-END'])
+            duration = end - begin
+            mid = begin + duration/2
+            newTime = dafBase.DateTime(mid.isoformat(), dafBase.DateTime.Timescale.TAI)
+            newVi = exp.visitInfo.copyWith(date=newTime)
+            exp.info.setVisitInfo(newVi)
+        except Exception as e:
+            self.log.warning(f"Failed to set date from header: {e}")
 
         return exp
 
@@ -425,6 +428,9 @@ class StarTrackerChannel():
         if not exp.wcs:
             self.log.info(f"Skipping {filename} as it has no WCS")
             return
+        if not exp.visitInfo.date.isValid():
+            self.log.warning(f"exp.visitInfo.date is not valid. {filename} will still be fitted"
+                             " but the alt/az values reported will be garbage")
 
         # metadata a shard with just the pointing info etc
         self.writeDefaultPointingShardForFilename(exp, filename)

--- a/python/lsst/rubintv/production/starTracker.py
+++ b/python/lsst/rubintv/production/starTracker.py
@@ -79,7 +79,8 @@ def getRawDataDirForDayObs(rootDataPath, wide, dayObs):
     """
     camNum = 101 if wide else 102  # TODO move this config to the top somehow?
     dayObsDateTime = datetime.datetime.strptime(str(dayObs), '%Y%m%d')
-    dirSuffix = f'GenericCamera/{camNum}/{dayObsDateTime.year}/{dayObsDateTime.month}/{dayObsDateTime.day}/'
+    dirSuffix = (f'GenericCamera/{camNum}/{dayObsDateTime.year}/'
+                 f'{dayObsDateTime.month:02}/{dayObsDateTime.day:02}/')
     return os.path.join(rootDataPath, dirSuffix)
 
 


### PR DESCRIPTION
Images with most of the headers missing can at least be displayed raw, so just add some `try` blocks and skip the processing, so that people can still follow the data taking on RubinTV.