### PR TITLE
DM-39554: Update base lsst_distrib stack for RubinTV at USDF

### DIFF
--- a/config/config_slac.yaml
+++ b/config/config_slac.yaml
@@ -3,8 +3,8 @@ dataIdScanPath: '/scratch/rubintv/dataIds'
 bucketName: 'rubintv_data_slac'
 
 # Butler paths - use full paths not aliases here as path existence is checked
-ts8ButlerPath: '/repo/ir2/butler.yaml'
-botButlerPath: '/repo/ir2/butler.yaml'
+ts8ButlerPath: '/sdf/group/rubin/repo/ir2/butler.yaml'
+botButlerPath: '/sdf/group/rubin/repo/ir2/butler.yaml'
 
 # # data paths
 scratchPath: '/scratch/rubintv'


### PR DESCRIPTION
This is needed to go with the mount change at
argocd-csc/services/rubintv-broadcaster

Having `/repo` on the container's filesystem is confusing and making it difficult to mount other folders in `/sdf/data/rubin`. Full paths as the butler root are used everywhere in RubinTV currently. (If not, they should be fixed.) 