### PR TITLE
DM-43345: Add new StarTracker plot for error vs position

### DIFF
--- a/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
+++ b/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
@@ -432,6 +432,7 @@ class CameraAzAltOffset(StarTrackerPlot):
         ax[1].set_ylabel("Arcsec", fontsize=13)
         return True
 
+
 class CameraAzAltOffsetPosition(StarTrackerPlot):
     _PlotName = 'CameraAzAltOffsetPosition'
     _PlotGroup = 'Analysis'
@@ -447,52 +448,60 @@ class CameraAzAltOffsetPosition(StarTrackerPlot):
                          uploader=uploader)
 
     def plot(self, metadata):
-        """Create a sample plot using data from the StarTracker page tables.                                                                    
-                                                                                                                                                
-        Parameters                                                                                                                              
-        ----------                                                                                                                              
-        metadata : `pandas.DataFrame`                                                                                                           
-            The data from all three StarTracker page tables, as a dataframe.                                                                    
-                                                                                                                                                
-        Returns                                                                                                                                 
-        -------                                                                                                                                 
-        success : `bool`                                                                                                                        
-            Did the plotting succeed, and thus upload should be performed?                                                                      
+        """Create a sample plot using data from the StarTracker page tables.
+
+        Parameters
+        ----------
+        metadata : `pandas.DataFrame`
+            The data from all three StarTracker page tables, as a dataframe.
+
+        Returns
+        -------
+        success : `bool`
+            Did the plotting succeed, and thus upload should be performed?
         """
         alt = metadata["Alt"]
         az = metadata["Az"]
         deltaAlt = metadata["Delta Alt Arcsec"]
         deltaAz = metadata["Delta Az Arcsec"]
+
         medDeltaAlt = np.nanmedian(deltaAlt)
         medDeltaAz = np.nanmedian(deltaAz)
         deltaAlt -= medDeltaAlt
         deltaAz -= medDeltaAz
+
         deltaAltWide = metadata["Delta Alt Arcsec wide"]
         deltaAzWide = metadata["Delta Az Arcsec wide"]
         medDeltaAltWide = np.nanmedian(deltaAltWide)
         medDeltaAzWide = np.nanmedian(deltaAzWide)
         deltaAltWide -= medDeltaAltWide
         deltaAzWide -= medDeltaAzWide
+
         fig, ax = plt.subplots(2, 2, figsize=(10, 8), sharex='col', sharey='row')
         fig.subplots_adjust(hspace=0, wspace=0)
         plt.suptitle(f"Median subtracted pointing errors vs position {self.dayObs}", fontsize=18)
+
         ax[0][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
         ax[0][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
         ax[0][0].set_ylabel("DeltaAlt (arcsec)", fontsize=13)
         ax[0][0].legend()
+
         ax[0][1].scatter(az, deltaAltWide, color='red', marker='o', label='Wide')
         ax[0][1].scatter(az, deltaAlt, color='blue', marker='x', label='Narrow')
         ax[0][1].legend()
+
         ax[1][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
         ax[1][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
-        ax[1][0].set_xlim(0,90)
-        ax[1][0].set_xticks([10,20,30,40,50,60,70,80])
+        ax[1][0].set_xlim(0, 90)
+        ax[1][0].set_xticks([10, 20, 30, 40, 50, 60, 70, 80])
         ax[1][0].set_xlabel("Alt (degrees)", fontsize=13)
         ax[1][0].set_ylabel("DeltaAz (arcsec)", fontsize=13)
         ax[1][0].legend()
+
         ax[1][1].scatter(az, deltaAltWide, color='red', marker='o', label='Wide')
         ax[1][1].scatter(az, deltaAlt, color='blue', marker='x', label='Narrow')
         ax[1][1].set_xlabel("Az (degrees)", fontsize=13)
-        ax[1][1].set_xlim(-150,150)
+        ax[1][1].set_xlim(-150, 150)
         ax[1][1].legend()
+
         return True

--- a/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
+++ b/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
@@ -23,6 +23,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from .nightReportPlotBase import StarTrackerPlot
+from lsst.utils.plotting.limits import calculate_safe_plotting_limits
 
 # any classes added to PLOT_FACTORIES will automatically be added to the night
 # report channel, with each being replotted for each image taken.
@@ -484,24 +485,30 @@ class CameraAzAltOffsetPosition(StarTrackerPlot):
         ax[0][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
         ax[0][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
         ax[0][0].set_ylabel("DeltaAlt (arcsec)", fontsize=13)
+        ymin, ymax = calculate_safe_plotting_limits([deltaAlt, deltaAltWide], \
+                                                    percentile=99.0)
+        ax[0][0].set_ylim(ymin, ymax)
         ax[0][0].legend()
 
         ax[0][1].scatter(az, deltaAltWide, color='red', marker='o', label='Wide')
         ax[0][1].scatter(az, deltaAlt, color='blue', marker='x', label='Narrow')
         ax[0][1].legend()
 
-        ax[1][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
-        ax[1][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
+        ax[1][0].scatter(alt, deltaAzWide, color='red', marker='o', label='Wide')
+        ax[1][0].scatter(alt, deltaAz, color='blue', marker='x', label='Narrow')
+        ymin, ymax = calculate_safe_plotting_limits([deltaAz, deltaAzWide], \
+                                                    percentile=99.0)
+        ax[1][0].set_ylim(ymin, ymax)
         ax[1][0].set_xlim(0, 90)
         ax[1][0].set_xticks([10, 20, 30, 40, 50, 60, 70, 80])
         ax[1][0].set_xlabel("Alt (degrees)", fontsize=13)
         ax[1][0].set_ylabel("DeltaAz (arcsec)", fontsize=13)
         ax[1][0].legend()
 
-        ax[1][1].scatter(az, deltaAltWide, color='red', marker='o', label='Wide')
-        ax[1][1].scatter(az, deltaAlt, color='blue', marker='x', label='Narrow')
+        ax[1][1].scatter(az, deltaAzWide, color='red', marker='o', label='Wide')
+        ax[1][1].scatter(az, deltaAz, color='blue', marker='x', label='Narrow')
         ax[1][1].set_xlabel("Az (degrees)", fontsize=13)
-        ax[1][1].set_xlim(-150, 150)
+        ax[1][1].set_xlim(-180, 180)
         ax[1][1].legend()
 
         return True

--- a/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
+++ b/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
@@ -485,7 +485,7 @@ class CameraAzAltOffsetPosition(StarTrackerPlot):
         ax[0][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
         ax[0][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
         ax[0][0].set_ylabel("DeltaAlt (arcsec)", fontsize=13)
-        ymin, ymax = calculate_safe_plotting_limits([deltaAlt, deltaAltWide], \
+        ymin, ymax = calculate_safe_plotting_limits([deltaAlt, deltaAltWide],
                                                     percentile=99.0)
         ax[0][0].set_ylim(ymin, ymax)
         ax[0][0].legend()
@@ -496,7 +496,7 @@ class CameraAzAltOffsetPosition(StarTrackerPlot):
 
         ax[1][0].scatter(alt, deltaAzWide, color='red', marker='o', label='Wide')
         ax[1][0].scatter(alt, deltaAz, color='blue', marker='x', label='Narrow')
-        ymin, ymax = calculate_safe_plotting_limits([deltaAz, deltaAzWide], \
+        ymin, ymax = calculate_safe_plotting_limits([deltaAz, deltaAzWide],
                                                     percentile=99.0)
         ax[1][0].set_ylim(ymin, ymax)
         ax[1][0].set_xlim(0, 90)

--- a/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
+++ b/python/lsst/rubintv/production/plotting/starTrackerNightReportPlots.py
@@ -33,6 +33,7 @@ PLOT_FACTORIES = ['RaDecAltAzOverTime',
                   'CameraPointingOffset',
                   'InterCameraOffset',
                   'CameraAzAltOffset',
+                  'CameraAzAltOffsetPosition',
                   ]
 
 __all__ = PLOT_FACTORIES
@@ -429,4 +430,69 @@ class CameraAzAltOffset(StarTrackerPlot):
         ax[1].legend()
         ax[1].set_title("Wide Cam")
         ax[1].set_ylabel("Arcsec", fontsize=13)
+        return True
+
+class CameraAzAltOffsetPosition(StarTrackerPlot):
+    _PlotName = 'CameraAzAltOffsetPosition'
+    _PlotGroup = 'Analysis'
+
+    def __init__(self,
+                 dayObs,
+                 locationConfig=None,
+                 uploader=None):
+        super().__init__(dayObs=dayObs,
+                         plotName=self._PlotName,
+                         plotGroup=self._PlotGroup,
+                         locationConfig=locationConfig,
+                         uploader=uploader)
+
+    def plot(self, metadata):
+        """Create a sample plot using data from the StarTracker page tables.                                                                    
+                                                                                                                                                
+        Parameters                                                                                                                              
+        ----------                                                                                                                              
+        metadata : `pandas.DataFrame`                                                                                                           
+            The data from all three StarTracker page tables, as a dataframe.                                                                    
+                                                                                                                                                
+        Returns                                                                                                                                 
+        -------                                                                                                                                 
+        success : `bool`                                                                                                                        
+            Did the plotting succeed, and thus upload should be performed?                                                                      
+        """
+        alt = metadata["Alt"]
+        az = metadata["Az"]
+        deltaAlt = metadata["Delta Alt Arcsec"]
+        deltaAz = metadata["Delta Az Arcsec"]
+        medDeltaAlt = np.nanmedian(deltaAlt)
+        medDeltaAz = np.nanmedian(deltaAz)
+        deltaAlt -= medDeltaAlt
+        deltaAz -= medDeltaAz
+        deltaAltWide = metadata["Delta Alt Arcsec wide"]
+        deltaAzWide = metadata["Delta Az Arcsec wide"]
+        medDeltaAltWide = np.nanmedian(deltaAltWide)
+        medDeltaAzWide = np.nanmedian(deltaAzWide)
+        deltaAltWide -= medDeltaAltWide
+        deltaAzWide -= medDeltaAzWide
+        fig, ax = plt.subplots(2, 2, figsize=(10, 8), sharex='col', sharey='row')
+        fig.subplots_adjust(hspace=0, wspace=0)
+        plt.suptitle(f"Median subtracted pointing errors vs position {self.dayObs}", fontsize=18)
+        ax[0][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
+        ax[0][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
+        ax[0][0].set_ylabel("DeltaAlt (arcsec)", fontsize=13)
+        ax[0][0].legend()
+        ax[0][1].scatter(az, deltaAltWide, color='red', marker='o', label='Wide')
+        ax[0][1].scatter(az, deltaAlt, color='blue', marker='x', label='Narrow')
+        ax[0][1].legend()
+        ax[1][0].scatter(alt, deltaAltWide, color='red', marker='o', label='Wide')
+        ax[1][0].scatter(alt, deltaAlt, color='blue', marker='x', label='Narrow')
+        ax[1][0].set_xlim(0,90)
+        ax[1][0].set_xticks([10,20,30,40,50,60,70,80])
+        ax[1][0].set_xlabel("Alt (degrees)", fontsize=13)
+        ax[1][0].set_ylabel("DeltaAz (arcsec)", fontsize=13)
+        ax[1][0].legend()
+        ax[1][1].scatter(az, deltaAltWide, color='red', marker='o', label='Wide')
+        ax[1][1].scatter(az, deltaAlt, color='blue', marker='x', label='Narrow')
+        ax[1][1].set_xlabel("Az (degrees)", fontsize=13)
+        ax[1][1].set_xlim(-150,150)
+        ax[1][1].legend()
         return True


### PR DESCRIPTION
New version of STarTracker night plots with error vs position added. Example plot here.
![RubinTV_Plot_20240301](https://github.com/lsst-sitcom/rubintv_production/assets/9419258/6a8dfcc9-abe3-41dd-a508-c8c3723eaf3d)
