### PR TITLE
Add mypy-coverage GitHub Action (informational)

### DIFF
--- a/.github/workflows/mypy-coverage.yaml
+++ b/.github/workflows/mypy-coverage.yaml
@@ -1,0 +1,57 @@
+name: "mypy coverage"
+
+# Runs https://github.com/mfisherlevine/mypy_coverage on every PR and on
+# pushes to main. Currently informational only (no threshold), so it can
+# never block a merge -- the value is the inline annotations on the PR
+# diff for unannotated / partially annotated definitions.
+#
+# To gate on a coverage floor in the future, add ``threshold: 85`` (or
+# whatever) under ``with:`` and add the job's name to the required
+# status checks for ``main`` in the branch protection settings.
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: "Annotate coverage gaps"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - id: mc
+        uses: mfisherlevine/mypy_coverage@v0.1.2
+        with:
+          version: "0.1.2"
+          format: github
+          # Use the repo's mypy.ini directly so we pick up the same
+          # exclude pattern, files=, and mypy_path= as the local mypy run.
+          config: mypy.ini
+          # Walled-off "Excluded files" section is informational; harmless
+          # in CI logs and useful for visibility into uploaders.py + the
+          # tests/ci/meta_*.py shims that mypy is configured to skip.
+          include-excluded: "true"
+      - name: "Coverage summary"
+        if: always()
+        run: |
+          {
+            echo "### mypy coverage"
+            echo
+            echo "| metric | value |"
+            echo "| --- | ---: |"
+            echo "| body-checked by mypy | ${{ steps.mc.outputs.percent-checked }}% |"
+            echo "| fully annotated      | ${{ steps.mc.outputs.percent-fully-typed }}% |"
+            echo "| unannotated defs     | ${{ steps.mc.outputs.unannotated }} |"
+            echo "| partial defs         | ${{ steps.mc.outputs.partial }} |"
+            echo "| total defs counted   | ${{ steps.mc.outputs.total }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mypy-coverage.yaml
+++ b/.github/workflows/mypy-coverage.yaml
@@ -30,9 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: mc
-        uses: mfisherlevine/mypy_coverage@v0.1.2
+        uses: mfisherlevine/mypy_coverage@v0.2.3
         with:
-          version: "0.1.2"
+          version: "0.2.3"
           format: github
           # Use the repo's mypy.ini directly so we pick up the same
           # exclude pattern, files=, and mypy_path= as the local mypy run.


### PR DESCRIPTION
Adds a workflow that runs [mypy-coverage](https://github.com/mfisherlevine/mypy_coverage) on every PR and on pushes to ``main``, surfacing inline annotations on the PR diff for unannotated and partially annotated definitions.

## What this gives us

- **Inline annotations** on the *Files changed* tab. Every fully-unannotated function (mypy silently skips these bodies under our current ``check_untyped_defs = False``) gets a yellow ``::warning``. Partial ones get ``::notice``. Reviewers can spot the gaps without running anything locally.
- **Summary table** in the Actions UI:

  | metric | value |
  | --- | ---: |
  | body-checked by mypy | ~87.2% |
  | fully annotated      | ~83.9% |
  | unannotated defs     | 158 |
  | partial defs         | 41 |

  (Numbers from the last local run on ``main``; this PR will produce the live ones in the run summary.)
- **Walled-off "Excluded files" view** for visibility on ``uploaders.py`` and the ``tests/ci/meta_*.py`` shims. Doesn't pollute the main numbers.

## What this does *not* do

- **No threshold gate.** The job exits 0 regardless of coverage, so it can never block a merge. Once we agree on a baseline we want to defend, add ``threshold: <pct>`` under ``with:`` and add the job's name (``Annotate coverage gaps``) to main's required status checks in branch protection.

## Implementation notes

- Uses the published action ``mfisherlevine/mypy_coverage@v0.1.2`` (pinned).
- Picks up our existing ``mypy.ini`` (same ``exclude``, ``files``, ``mypy_path`` as local mypy).
- 5-minute timeout. Should usually finish in well under a minute.
- The action is also available on PyPI as ``mypy-coverage`` if anyone wants to run it locally: ``pip install mypy-coverage; mypy-coverage``.