### PR TITLE
DM-55462: Set Sentry environment from RAPID_ANALYSIS_LOCATION

### DIFF
--- a/python/lsst/rubintv/production/startupChecks.py
+++ b/python/lsst/rubintv/production/startupChecks.py
@@ -31,6 +31,7 @@ away entirely).
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import sentry_sdk
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "getSentryEnvironment",
     "setupSentry",
     "checkRubinTvExternalPackages",
 ]
@@ -55,13 +57,39 @@ GOOGLE_CLOUD_MISSING_MSG = (
 )
 
 
+def getSentryEnvironment() -> str | None:
+    """Get the environment name to report to Sentry for this process.
+
+    ``SENTRY_ENVIRONMENT`` takes precedence when set, falling back to
+    ``RAPID_ANALYSIS_LOCATION``, which every deployed pod sets (e.g.
+    ``SUMMIT``, ``BTS``, ``USDF``). Empty strings are treated as unset.
+
+    Returns
+    -------
+    environment : `str` or `None`
+        The environment name, or `None` if neither variable is set, in
+        which case the Sentry SDK falls back to its default of
+        ``production``.
+    """
+    return os.environ.get("SENTRY_ENVIRONMENT") or os.environ.get("RAPID_ANALYSIS_LOCATION") or None
+
+
 def setupSentry() -> None:
-    """Set up sentry"""
-    sentry_sdk.init()
+    """Set up sentry.
+
+    Initializes the Sentry SDK with the reporting environment set to the
+    deployment site (e.g. ``SUMMIT``, ``BTS``) so that events and alert
+    emails identify where they came from, rather than carrying the SDK's
+    default environment of ``production``.
+    """
+    logger = logging.getLogger(__name__)
+    environment = getSentryEnvironment()
+    if environment is None:
+        logger.warning("No Sentry environment found - events will be reported as 'production'")
+    sentry_sdk.init(environment=environment)
     client = sentry_sdk.get_client()  # never None, but inactive if failing to initialize
     if not client.is_active() or client.dsn is None:
-        logger = logging.getLogger(__name__)
-        logger.warning("Sentry DSN not found or client inactive — events will not be reported")
+        logger.warning("Sentry DSN not found or client inactive - events will not be reported")
 
 
 def checkRubinTvExternalPackages(exitIfNotFound: bool = True, logger: Logger | None = None) -> None:

--- a/tests/test_startupChecks.py
+++ b/tests/test_startupChecks.py
@@ -1,0 +1,81 @@
+# This file is part of rubintv_production.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Test cases for startupChecks.
+
+Pins the Sentry environment resolution in ``getSentryEnvironment``. The
+worker-set pods only get ``RAPID_ANALYSIS_LOCATION`` from the Helm charts
+(not ``SENTRY_ENVIRONMENT``), and the Sentry SDK silently files events
+under ``production`` when it can't resolve an environment — so a
+regression here wouldn't fail anything visibly, it would just quietly
+mislabel every worker's error reports again (DM-55462).
+"""
+
+import unittest
+from unittest.mock import patch
+
+import lsst.utils.tests
+from lsst.rubintv.production.startupChecks import getSentryEnvironment
+
+
+class GetSentryEnvironmentTestCase(lsst.utils.tests.TestCase):
+    """Tests for the SENTRY_ENVIRONMENT / RAPID_ANALYSIS_LOCATION fallback
+    chain.
+    """
+
+    def testSentryEnvironmentTakesPrecedence(self) -> None:
+        env = {"SENTRY_ENVIRONMENT": "SOMEWHERE", "RAPID_ANALYSIS_LOCATION": "SUMMIT"}
+        with patch.dict("os.environ", env, clear=True):
+            self.assertEqual(getSentryEnvironment(), "SOMEWHERE")
+
+    def testFallsBackToRapidAnalysisLocation(self) -> None:
+        with patch.dict("os.environ", {"RAPID_ANALYSIS_LOCATION": "BTS"}, clear=True):
+            self.assertEqual(getSentryEnvironment(), "BTS")
+
+    def testEmptySentryEnvironmentFallsThrough(self) -> None:
+        # The Helm charts quote the location value, so an unset location
+        # would arrive as an empty string rather than an absent variable —
+        # empty must mean "unset", not "the empty environment".
+        env = {"SENTRY_ENVIRONMENT": "", "RAPID_ANALYSIS_LOCATION": "SUMMIT"}
+        with patch.dict("os.environ", env, clear=True):
+            self.assertEqual(getSentryEnvironment(), "SUMMIT")
+
+    def testReturnsNoneWhenNothingSet(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertIsNone(getSentryEnvironment())
+
+    def testReturnsNoneWhenOnlyEmptyStringsSet(self) -> None:
+        env = {"SENTRY_ENVIRONMENT": "", "RAPID_ANALYSIS_LOCATION": ""}
+        with patch.dict("os.environ", env, clear=True):
+            self.assertIsNone(getSentryEnvironment())
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module: object) -> None:
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
The Helm charts only set SENTRY_ENVIRONMENT on the Deployment-template pods; the 16 StatefulSet worker/gather templates never got it, so the Sentry SDK filed every worker event under its default environment of "production" instead of SUMMIT/BTS. Since every pod template does set RAPID_ANALYSIS_LOCATION, resolve the environment in setupSentry() instead: SENTRY_ENVIRONMENT when set, falling back to RAPID_ANALYSIS_LOCATION, with empty strings treated as unset. This makes the environment tagging immune to per-template drift in the charts, and logs a warning when no environment can be resolved.